### PR TITLE
Fix warnings

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -19,6 +19,8 @@ module.exports = {
   ],
   // add your custom rules here
   rules: {
-    'max-len': ["error", { "code": 120 }]
+    'max-len': ["error", { "code": 120 }],
+    'vue/require-prop-types': "off",
+    'vue/require-default-prop': "off"
   }
 }

--- a/app/router.scrollBehavior.js
+++ b/app/router.scrollBehavior.js
@@ -1,0 +1,30 @@
+export default async function (to, from, savedPosition) {
+  if (savedPosition) {
+    return savedPosition
+  }
+
+  const findEl = (hash, x) => {
+    return (
+      document.querySelector(hash) ||
+      new Promise((resolve, reject) => {
+        if (x > 50) {
+          return resolve()
+        }
+        setTimeout(() => {
+          resolve(findEl(hash, ++x || 1))
+        }, 100)
+      })
+    )
+  }
+
+  if (to.hash) {
+    const el = await findEl(to.hash)
+    if ('scrollBehavior' in document.documentElement.style) {
+      return window.scrollTo({ top: el.offsetTop, behavior: 'smooth' })
+    } else {
+      return window.scrollTo(0, el.offsetTop)
+    }
+  }
+
+  return { x: 0, y: 0 }
+}

--- a/components/Activities.vue
+++ b/components/Activities.vue
@@ -77,8 +77,8 @@ import Zondicon from 'vue-zondicons'
 import activitiesFile from '~/static/activities.json'
 
 export default {
-  props: ['title'],
   components: { Zondicon },
+  props: ['title'],
   data() {
     return {
       activities: JSON.parse(JSON.stringify(activitiesFile))

--- a/components/BoardMember.vue
+++ b/components/BoardMember.vue
@@ -15,7 +15,7 @@ export default {
           <foreignObject width="100%" height="100%" x="0" y="0" externalResourcesRequired="true">
           <span xmlns="http://www.w3.org/1999/xhtml" style="
             color: rgb(255, 255, 255);
-            font: 16px / 20px &quot;Source Sans Pro&quot;, -apple-system, system-ui, &quot;Segoe UI&quot;, 
+            font: 16px / 20px &quot;Source Sans Pro&quot;, -apple-system, system-ui, &quot;Segoe UI&quot;,
                   Roboto, &quot;Helvetica Neue&quot;, Arial, sans-serif;
             font-kerning: auto;
             font-optical-sizing: auto;

--- a/components/EatingOut.vue
+++ b/components/EatingOut.vue
@@ -6,8 +6,8 @@
           <div class="rounded-full w-20 h-20 p-6 bg-purple-500 mt-2 mb-8 text-white mx-auto">
             <Zondicon icon="location-food" class="fill-current" />
           </div>
-          <h3 class="text-3xl font-semibold text-center" v-text="title" />
-          <h4 class="text-xl tracking-wide text-center" v-text="subtitle" />
+          <h3 v-text="title" class="text-3xl font-semibold text-center" />
+          <h4 v-text="subtitle" class="text-xl tracking-wide text-center" />
         </div>
         <div class="relative">
           <div class="triangle md:hidden" />
@@ -19,7 +19,7 @@
                 <a href="/eatingout" target="_blank">
                   <button class="block button-white z-50 text-purple-500 text-left mb-2">
                     <div class="flex items-center">
-                      <div class="max-w-56" v-text="button" />
+                      <div v-text="button" class="max-w-56" />
                       <div><Zondicon icon="cheveron-outline-right" class="h-8" /></div>
                     </div>
                   </button>
@@ -40,8 +40,8 @@
 import Zondicon from 'vue-zondicons'
 
 export default {
-  props: ['title', 'subtitle', 'button', 'notes'],
-  components: { Zondicon }
+  components: { Zondicon },
+  props: ['title', 'subtitle', 'button', 'notes']
 }
 </script>
 

--- a/components/FilesList.vue
+++ b/components/FilesList.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="shadow-xl p-4 rounded-lg mb-12 bg-gray-200" v-if="files.length > 0">
+  <div v-if="files.length > 0" class="shadow-xl p-4 rounded-lg mb-12 bg-gray-200">
     <div class="-mb-4 text-lg">
       <div v-for="file in files" :key="file.id">
         <a :href="file.webViewLink" target="_blank">

--- a/components/Footer.vue
+++ b/components/Footer.vue
@@ -19,25 +19,25 @@
             <div class="rounded-full w-8 h-8 p-2 bg-white text-gray-700">
               <Zondicon icon="envelope" class="fill-current w-4" />
             </div>
-            <div class="ml-3" v-html="contactEmail" />
+            <div v-html="contactEmail" class="ml-3" />
           </div>
           <div class="flex items-center mb-4">
             <div class="rounded-full w-8 h-8 p-2 bg-white text-gray-700">
               <Zondicon icon="phone" class="fill-current w-4" />
             </div>
-            <div class="ml-3" v-html="contactPhone" />
+            <div v-html="contactPhone" class="ml-3" />
           </div>
           <div class="flex items-center mb-4">
             <div class="rounded-full w-8 h-8 p-2 bg-white text-gray-700">
               <Zondicon icon="map" class="fill-current w-4" />
             </div>
-            <div class="ml-3 leading-tight" v-html="contactAddress" />
+            <div v-html="contactAddress" class="ml-3 leading-tight" />
           </div>
           <div class="flex items-center mb-4">
             <div class="rounded-full w-8 h-8 p-2 bg-white text-gray-700">
               <Zondicon icon="box" class="fill-current w-4" />
             </div>
-            <div class="ml-3 leading-tight" v-html="contactCoc" />
+            <div v-html="contactCoc" class="ml-3 leading-tight" />
           </div>
           <div class="mb-2">
             <a
@@ -109,16 +109,6 @@ import FacebookIcon from '@/assets/images/social/facebook.svg'
 import GitHubIcon from '@/assets/images/social/github.svg'
 
 export default {
-  props: [
-    'left-title',
-    'right-title',
-    'board-image',
-    'contact-email',
-    'contact-phone',
-    'contact-address',
-    'contact-coc',
-    'anbi-link-destination'
-  ],
   components: {
     Zondicon,
     DWHLogo,
@@ -126,6 +116,16 @@ export default {
     FacebookIcon,
     GitHubIcon
   },
+  props: [
+    'leftTitle',
+    'rightTitle',
+    'boardImage',
+    'contactEmail',
+    'contactPhone',
+    'contactAddress',
+    'contactCoc',
+    'anbiLinkDestination'
+  ],
   data() {
     return {
       year: dayjs().format('YYYY')

--- a/components/Header.vue
+++ b/components/Header.vue
@@ -31,12 +31,12 @@
             </a>
           </div>
           <div
+            @click="showMenu = !showMenu"
             class="
               rounded-full w-7 h-7 p-1 bg-white mr-1 md:mr-4 border-2 border-white
               flex items-center justify-center md:hidden
               overflow-hidden relative
             "
-            @click="showMenu = !showMenu"
           >
             <Zondicon v-if="!showMenu" icon="menu" class="fill-current w-full" />
             <Zondicon v-if="showMenu" icon="close" class="fill-current w-full" />
@@ -63,13 +63,13 @@ import NLFlag from '@/assets/images/flags/nl.svg'
 import GBFlag from '@/assets/images/flags/gb.svg'
 
 export default {
-  props: ['small'],
   components: {
     DWHLogo,
     NLFlag,
     GBFlag,
     Zondicon
   },
+  props: ['small'],
   data() {
     return {
       showMenu: false,

--- a/components/JoinNewsletter.vue
+++ b/components/JoinNewsletter.vue
@@ -12,13 +12,13 @@
         </div>
         <form
           id="mc-embedded-subscribe-form"
+          @submit="submitForm()"
           action="https://dwhdelft.us3.list-manage.com/subscribe/post?u=8c9a6403988df86ce2cfd009e&amp;id=275d74c087"
           method="post"
           name="mc-embedded-subscribe-form"
           class="validate"
           target="_blank"
           novalidate
-          @submit="submitForm()"
         >
           <div class="py-4 px-8 flex items-center justify-center text-black">
             <div>
@@ -26,8 +26,8 @@
               <div class="flex justify-center">
                 <input
                   v-model="email"
-                  type="email"
                   :placeholder="$t('forms.placeholder.email')"
+                  type="email"
                   name="EMAIL"
                   class="bg-gray-200 rounded-lg block px-4 py-2 w-full mr-4"
                   required
@@ -51,10 +51,10 @@
 import Zondicon from 'vue-zondicons'
 
 export default {
-  props: ['button-text', 'button-target'],
   components: {
     Zondicon
   },
+  props: ['buttonText', 'buttonTarget'],
   data() {
     return {
       email: ''

--- a/components/JoinOptions.vue
+++ b/components/JoinOptions.vue
@@ -3,9 +3,9 @@
     <div class="md:flex justify-center">
       <div class="flex-1 mx-2 flex items-end mt-4">
         <div class="text-white">
-          <h1 class="font-medium leading-none text-5xl mb-4" v-html="title"></h1>
-          <p class="text-lg md:pr-40 mb-4" v-html="description" />
-          <p class="text-lg md:pr-40" v-html="outsiteHint" />
+          <h1 v-html="title" class="font-medium leading-none text-5xl mb-4"></h1>
+          <p v-html="description" class="text-lg md:pr-40 mb-4" />
+          <p v-html="outsiteHint" class="text-lg md:pr-40" />
         </div>
       </div>
       <div class="bg-white rounded-lg md:rounded-t-none p-8 flex-1 mx-2 flex flex-col justify-between mt-6 md:mt-0">
@@ -36,7 +36,7 @@
 import Zondicon from 'vue-zondicons'
 
 export default {
-  props: ['title', 'description', 'outsiteHint', 'boxIcon', 'boxTitle', 'boxButtonText', 'boxUrl'],
-  components: { Zondicon }
+  components: { Zondicon },
+  props: ['title', 'description', 'outsiteHint', 'boxIcon', 'boxTitle', 'boxButtonText', 'boxUrl']
 }
 </script>

--- a/components/RecurringEvents.vue
+++ b/components/RecurringEvents.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="container px-4 mx-auto py-16 md:pb-24">
-    <h2 class="text-center text-purple-500 font-medium text-5xl mb-12 leading-tight" v-html="announcement" />
+    <h2 v-html="announcement" class="text-center text-purple-500 font-medium text-5xl mb-12 leading-tight" />
     <div class="md:flex flex-wrap justify-center -mx-2">
       <div
         v-for="event in $t('recurring_events.events')"
@@ -10,9 +10,9 @@
       >
         <div class="p-6 md:mb-6">
           <div class="flex mb-2">
-            <h4 class="flex-1 text-purple-500 font-semibold text-2xl" v-text="event.name" />
+            <h4 v-text="event.name" class="flex-1 text-purple-500 font-semibold text-2xl" />
             <div v-if="event.note" class="ml-4 text-center flex items-center">
-              <div class="bg-purple-200 rounded-lg px-2 py-1 text-xs uppercase tracking-wider" v-text="event.note" />
+              <div v-text="event.note" class="bg-purple-200 rounded-lg px-2 py-1 text-xs uppercase tracking-wider" />
             </div>
           </div>
           <div class="bg-white rounded px-3 mb-4 tracking-wider flex items-center border border-purple-200">
@@ -20,7 +20,7 @@
             <div class="flex-1 py-2">
               {{ event.day }}
             </div>
-            <div class="border-l border-purple-200 pl-3 py-2" v-text="event.time" />
+            <div v-text="event.time" class="border-l border-purple-200 pl-3 py-2" />
           </div>
           <p>
             {{ event.description }}
@@ -28,10 +28,10 @@
         </div>
         <a
           v-if="event.buttonText"
-          class="bg-purple-500 hover:bg-purple-300 py-3 rounded-b text-white
-                 uppercase font-semibold tracking-wider text-center"
           :href="event.buttonLink"
           v-html="event.buttonText"
+          class="bg-purple-500 hover:bg-purple-300 py-3 rounded-b text-white
+                 uppercase font-semibold tracking-wider text-center"
         />
       </div>
     </div>
@@ -40,10 +40,10 @@
         <div class="rounded-full w-7 h-7 bg-white mr-3 flex items-center justify-center">
           <Zondicon icon="arrow-thin-right" class="w-4 text-purple-500 fill-current" />
         </div>
-        <div class="flex-1 text-lg font-semibold text-white" v-html="$t('recurring_events.saturday.title')" />
+        <div v-html="$t('recurring_events.saturday.title')" class="flex-1 text-lg font-semibold text-white" />
         <div
-          class="bg-white rounded-lg px-2 py-1 text-xs uppercase tracking-wider absolute right-0 -top-3 h-6 shadow mr-4"
           v-text="$t('recurring_events.saturday.note')"
+          class="bg-white rounded-lg px-2 py-1 text-xs uppercase tracking-wider absolute right-0 -top-3 h-6 shadow mr-4"
         />
       </div>
     </div>
@@ -54,7 +54,7 @@
 import Zondicon from 'vue-zondicons'
 
 export default {
-  props: ['title', 'url', 'announcement'],
-  components: { Zondicon }
+  components: { Zondicon },
+  props: ['title', 'url', 'announcement']
 }
 </script>

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -6,19 +6,19 @@
       <Footer
         :left-title="$t('footer.leftTitle')"
         :right-title="$t('footer.rightTitle')"
+        :anbi-link-destination="localePath('anbi')"
         contact-email="bestuur@dwhdelft.nl"
         contact-address="Lange Geer 22<br />2611PV Delft"
         contact-phone="06-37560270"
         contact-coc="KvK: 40398035<br />RSIN: 807864250"
-        :anbi-link-destination="localePath('anbi')"
       >
         <template v-slot:board-members>
-          <BoardMember name="Robert Baart" :role="$t('footer.board.president')" email="voorzitter@dwhdelft.nl" />
-          <BoardMember name="Casper Boone" :role="$t('footer.board.youth')" email="jongeren@dwhdelft.nl" />
-          <BoardMember name="Nick van Loo" :role="$t('footer.board.secretary')" email="secretaris@dwhdelft.nl" />
-          <BoardMember name="Jelle Vos" :role="$t('footer.board.general')" email="promotie@dwhdelft.nl" />
-          <BoardMember name="Quinten Star" :role="$t('footer.board.treasurer')" email="penningmeester@dwhdelft.nl" />
-          <BoardMember name="Jeroen Wegdam" :role="$t('footer.board.general')" email="pand@dwhdelft.nl" />
+          <BoardMember :role="$t('footer.board.president')" name="Robert Baart" email="voorzitter@dwhdelft.nl" />
+          <BoardMember :role="$t('footer.board.youth')" name="Casper Boone" email="jongeren@dwhdelft.nl" />
+          <BoardMember :role="$t('footer.board.secretary')" name="Nick van Loo" email="secretaris@dwhdelft.nl" />
+          <BoardMember :role="$t('footer.board.general')" name="Jelle Vos" email="promotie@dwhdelft.nl" />
+          <BoardMember :role="$t('footer.board.treasurer')" name="Quinten Star" email="penningmeester@dwhdelft.nl" />
+          <BoardMember :role="$t('footer.board.general')" name="Jeroen Wegdam" email="pand@dwhdelft.nl" />
         </template>
         <template v-slot:newsletter>
           <JoinNewsletter :button-text="$t('footer.newsletter.button')">

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -106,38 +106,6 @@ export default {
       })
     }
   },
-  router: {
-    scrollBehavior: async (to, from, savedPosition) => {
-      if (savedPosition) {
-        return savedPosition
-      }
-
-      const findEl = (hash, x) => {
-        return (
-          document.querySelector(hash) ||
-          new Promise((resolve, reject) => {
-            if (x > 50) {
-              return resolve()
-            }
-            setTimeout(() => {
-              resolve(findEl(hash, ++x || 1))
-            }, 100)
-          })
-        )
-      }
-
-      if (to.hash) {
-        const el = await findEl(to.hash)
-        if ('scrollBehavior' in document.documentElement.style) {
-          return window.scrollTo({ top: el.offsetTop, behavior: 'smooth' })
-        } else {
-          return window.scrollTo(0, el.offsetTop)
-        }
-      }
-
-      return { x: 0, y: 0 }
-    }
-  },
 
   netlify: {
     redirects: [

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -53,7 +53,10 @@ export default {
   ],
 
   i18n: {
-    locales: [{ code: 'nl', iso: 'nl-NL', file: 'nl.js' }, { code: 'en', iso: 'en-US', file: 'en.js' }],
+    locales: [
+      { code: 'nl', iso: 'nl-NL', file: 'nl.js' },
+      { code: 'en', iso: 'en-US', file: 'en.js' }
+    ],
     defaultLocale: 'nl',
     langDir: 'lang/',
     lazy: true,

--- a/pages/anbi.vue
+++ b/pages/anbi.vue
@@ -10,13 +10,13 @@
 
     <section class="container mx-auto  text-xl md:text-2xl leading-normal text-gray-800">
       <div class="md:w-2/3 mx-4 md:mx-auto">
-        <div class="mt-8 md:mt-0 mb-8" v-html="$t('anbi.main_text')" />
-        <div class="mb-4" v-html="$t('anbi.annual_report')" />
-        <FilesList folderId="1SEhPdLmDC-MxwcqiRnaMlAcvoPgnq16a" />
-        <div class="mb-4" v-html="$t('anbi.annual_plan')" />
-        <FilesList folderId="1Y_3eX7L6RKOnFMCi1m3YP4Dkwc9Ibw2Y" />
-        <div class="mb-4" v-html="$t('anbi.financial')" />
-        <FilesList folderId="1wOt93uBOFba4lHrf6In1YZJPzT4L9Doi" />
+        <div v-html="$t('anbi.main_text')" class="mt-8 md:mt-0 mb-8" />
+        <div v-html="$t('anbi.annual_report')" class="mb-4" />
+        <FilesList folder-id="1SEhPdLmDC-MxwcqiRnaMlAcvoPgnq16a" />
+        <div v-html="$t('anbi.annual_plan')" class="mb-4" />
+        <FilesList folder-id="1Y_3eX7L6RKOnFMCi1m3YP4Dkwc9Ibw2Y" />
+        <div v-html="$t('anbi.financial')" class="mb-4" />
+        <FilesList folder-id="1wOt93uBOFba4lHrf6In1YZJPzT4L9Doi" />
       </div>
     </section>
   </div>

--- a/pages/andersblad.vue
+++ b/pages/andersblad.vue
@@ -10,14 +10,14 @@
 
     <section class="container mx-auto mb-12 text-xl md:text-2xl leading-normal text-gray-800">
       <div class="md:w-2/3 mx-4 md:mx-auto">
-        <p class="mt-8 md:mt-0 mb-8" v-html="$t('andersblad.main_text')" />
+        <p v-html="$t('andersblad.main_text')" class="mt-8 md:mt-0 mb-8" />
       </div>
     </section>
 
-    <section class="bg-purple-400" v-if="editions.length > 0">
+    <section v-if="editions.length > 0" class="bg-purple-400">
       <div class="container px-4 mx-auto pt-8 pb-12">
         <div class="text-center mb-6">
-          <h1 class="text-white font-medium text-5xl" v-html="$t('andersblad.list_title')" />
+          <h1 v-html="$t('andersblad.list_title')" class="text-white font-medium text-5xl" />
         </div>
         <div class="flex flex-wrap justify-center">
           <div v-for="edition in editions" :key="edition.id" class="md:w-1/3 p-4">

--- a/pages/barbuddy.vue
+++ b/pages/barbuddy.vue
@@ -10,19 +10,19 @@
 
     <section class="container mx-auto pb-4 text-xl md:text-2xl leading-normal text-gray-800">
       <div class="md:w-2/3 mx-4 md:mx-auto">
-        <p class="mt-8 mb-4 md:mt-0 md:mb-12" v-html="$t('ways_to_join.bar_buddy.description')" />
+        <p v-html="$t('ways_to_join.bar_buddy.description')" class="mt-8 mb-4 md:mt-0 md:mb-12" />
 
         <div class="shadow bg-purple-500 p-4 rounded mb-8 inline-flex items-center">
           <div
             class="
               rounded-full w-7 h-7 bg-white mr-2 border-2 border-white
-              flex items-center justify-center 
-              overflow-hidden relative 
+              flex items-center justify-center
+              overflow-hidden relative
             "
           >
             <Zondicon icon="arrow-thin-right" class="w-4 text-purple-500 fill-current" />
           </div>
-          <div class="text-lg font-semibold text-white flex-1" v-html="$t('ways_to_join.bar_buddy.thursday_note')" />
+          <div v-html="$t('ways_to_join.bar_buddy.thursday_note')" class="text-lg font-semibold text-white flex-1" />
         </div>
       </div>
     </section>
@@ -30,7 +30,7 @@
     <section class="bg-purple-300">
       <div class="container px-4 mx-auto pt-8 pb-12">
         <div class="text-center">
-          <h1 class="text-white font-medium text-5xl" v-html="$t('ways_to_join.bar_buddy.barbuddies_title')" />
+          <h1 v-html="$t('ways_to_join.bar_buddy.barbuddies_title')" class="text-white font-medium text-5xl" />
         </div>
         <div class="md:flex flex-wrap -mx-2 mt-2">
           <div v-for="buddy in barbuddies" :key="buddy.name" class="md:w-1/2 p-2">
@@ -44,7 +44,7 @@
                     {{ buddy.name }}
                   </h2>
                 </div>
-                <button class="button-pink flex items-center hidden md:flex" @click="meetWith(buddy)">
+                <button @click="meetWith(buddy)" class="button-pink flex items-center hidden md:flex">
                   {{ $t('ways_to_join.bar_buddy.meet_up_with') }} {{ buddy.name }}
                   <Zondicon icon="arrow-thin-right" class="ml-2 w-4 fill-current" />
                 </button>
@@ -52,13 +52,13 @@
               <p :class="['text-lg relative', buddy.readMore ? 'pb-8' : 'clamp-lines']">
                 <span class="absolute bottom-0 right-0 flex">
                   <span class="w-32 block white-gradient" />
-                  <a class="text-purple-500 bg-white cursor-pointer" @click="readMore(buddy)">
+                  <a @click="readMore(buddy)" class="text-purple-500 bg-white cursor-pointer">
                     {{ $t('ways_to_join.bar_buddy.' + (buddy.readMore ? 'read_less' : 'read_more')) }}
                   </a>
                 </span>
                 {{ buddy.bio }}
               </p>
-              <button class="button-pink flex items-center mt-4 flex md:hidden" @click="meetWith(buddy)">
+              <button @click="meetWith(buddy)" class="button-pink flex items-center mt-4 flex md:hidden">
                 {{ $t('ways_to_join.bar_buddy.meet_up_with') }} {{ buddy.name }}
                 <Zondicon icon="arrow-thin-right" class="ml-2 w-4 fill-current" />
               </button>
@@ -86,10 +86,10 @@
             </div>
           </div>
         </div>
-        <form v-if="formStatus !== 'finished'" class="md:w-2/3 mx-4 md:mx-auto mt-8 md:my-12" @submit="submit">
+        <form v-if="formStatus !== 'finished'" @submit="submit" class="md:w-2/3 mx-4 md:mx-auto mt-8 md:my-12">
           <p class="form-element">
             <label class="required">{{ $t('forms.label.name') }}</label>
-            <input v-model="form.name" type="text" :placeholder="$t('forms.placeholder.name')" required />
+            <input v-model="form.name" :placeholder="$t('forms.placeholder.name')" type="text" required />
           </p>
           <p class="form-element">
             <label class="required">{{ $t('forms.label.language') }}</label>
@@ -108,15 +108,15 @@
           </p>
           <p class="form-element">
             <label class="required">{{ $t('forms.label.email') }}</label>
-            <input v-model="form.email" type="email" :placeholder="$t('forms.placeholder.email')" required />
+            <input v-model="form.email" :placeholder="$t('forms.placeholder.email')" type="email" required />
           </p>
           <p class="form-element">
             <label>{{ $t('forms.label.phone_number') }}</label>
-            <input v-model="form.phoneNumber" type="text" :placeholder="$t('forms.placeholder.phone_number')" />
+            <input v-model="form.phoneNumber" :placeholder="$t('forms.placeholder.phone_number')" type="text" />
           </p>
           <p class="form-element">
             <label>{{ $t('forms.label.pronouns') }}</label>
-            <input v-model="form.pronouns" type="text" :placeholder="$t('forms.placeholder.pronouns')" />
+            <input v-model="form.pronouns" :placeholder="$t('forms.placeholder.pronouns')" type="text" />
           </p>
           <p class="form-element">
             <label class="required">{{ $t('forms.label.barbuddy') }}</label>
@@ -125,7 +125,7 @@
               {{ $t('forms.label.languages.no_preference') }}
             </label>
             <label v-for="buddy in barbuddies" :key="buddy.name" class="radio">
-              <input v-model="form.barbuddy" type="radio" :value="buddy.name" :checked="buddy.selected" />
+              <input v-model="form.barbuddy" :value="buddy.name" :checked="buddy.selected" type="radio" />
               {{ buddy.name }}
             </label>
           </p>
@@ -135,7 +135,7 @@
           </p>
           <div id="recaptcha" />
           <p class="mt-8 md:my-8 text-right">
-            <button type="submit" class="button-pink" :disabled="formStatus === 'loading'">
+            <button :disabled="formStatus === 'loading'" type="submit" class="button-pink">
               {{ formStatus === 'loading' ? $t('forms.buttons.loading') : $t('forms.buttons.sign_up') }}
             </button>
           </p>

--- a/pages/education.vue
+++ b/pages/education.vue
@@ -10,7 +10,7 @@
 
     <section class="container mx-auto  text-xl md:text-2xl leading-normal text-gray-800">
       <div class="md:w-2/3 mx-4 md:mx-auto">
-        <p class="mt-8 md:mt-0 mb-8" v-html="$t('education.main_text')" />
+        <p v-html="$t('education.main_text')" class="mt-8 md:mt-0 mb-8" />
       </div>
     </section>
   </div>

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -26,7 +26,7 @@
     <section class="introduction overflow-x-hidden">
       <div class="container mx-auto pt-12 pb-24 md:flex">
         <div class="flex-1 md:w-1/2 px-4 md:pr-16">
-          <p class="text-lg md:text-xl leading-relaxed text-gray-800" v-html="$t('description.text')"></p>
+          <p v-html="$t('description.text')" class="text-lg md:text-xl leading-relaxed text-gray-800"></p>
           <div
             class="
               flex-1 rounded shadow-xl bg-purple-500 text-lg md:text-xl text-white my-12 md:mt-10 md:mb-24 p-4 relative
@@ -41,7 +41,7 @@
             >
               <Zondicon icon="explore" class="fill-current" />
             </div>
-            <div class="mt-6 md:mt-0 md:ml-4" v-html="$t('description.invitation')" />
+            <div v-html="$t('description.invitation')" class="mt-6 md:mt-0 md:ml-4" />
           </div>
         </div>
         <div class="hidden md:block">
@@ -61,14 +61,10 @@
         :title="$t('ways_to_join.title')"
         :description="$t('ways_to_join.description')"
         :outsite-hint="$t('ways_to_join.outsite_hint')"
-        left-icon="user-group"
-        :left-title="$t('ways_to_join.kmg.title')"
-        :left-button-text="$t('ways_to_join.kmg.action')"
-        :left-url="localePath('kmg')"
-        box-icon="beverage"
         :box-title="$t('ways_to_join.bar_buddy.title')"
         :box-button-text="$t('ways_to_join.bar_buddy.action')"
         :box-url="localePath('barbuddy')"
+        box-icon="beverage"
       >
         <template v-slot:left>
           {{ $t('ways_to_join.kmg.description') }}

--- a/pages/signup.vue
+++ b/pages/signup.vue
@@ -10,7 +10,7 @@
 
     <section class="container mx-auto mb-12 text-xl md:text-2xl leading-normal text-gray-800">
       <div class="md:w-2/3 mx-4 md:mx-auto">
-        <p class="mt-8 md:mt-0 mb-8" v-html="$t('signup.main_text')" />
+        <p v-html="$t('signup.main_text')" class="mt-8 md:mt-0 mb-8" />
       </div>
     </section>
 
@@ -32,18 +32,18 @@
             </div>
           </div>
         </div>
-        <form v-if="formStatus !== 'finished'" class="md:w-2/3 mx-4 md:mx-auto mt-8 md:my-12" @submit="submit">
+        <form v-if="formStatus !== 'finished'" @submit="submit" class="md:w-2/3 mx-4 md:mx-auto mt-8 md:my-12">
           <p class="form-element">
             <label class="required">{{ $t('forms.label.firstname') }}</label>
-            <input v-model="form.firstname" type="text" :placeholder="$t('forms.placeholder.firstname')" required />
+            <input v-model="form.firstname" :placeholder="$t('forms.placeholder.firstname')" type="text" required />
           </p>
           <p class="form-element">
             <label class="required">{{ $t('forms.label.initials') }}</label>
-            <input v-model="form.initials" type="text" :placeholder="$t('forms.placeholder.initials')" required />
+            <input v-model="form.initials" :placeholder="$t('forms.placeholder.initials')" type="text" required />
           </p>
           <p class="form-element">
             <label class="required">{{ $t('forms.label.lastname') }}</label>
-            <input v-model="form.lastname" type="text" :placeholder="$t('forms.placeholder.lastname')" required />
+            <input v-model="form.lastname" :placeholder="$t('forms.placeholder.lastname')" type="text" required />
           </p>
           <p class="form-element">
             <label class="required">{{ $t('forms.label.language') }}</label>
@@ -74,7 +74,7 @@
           </p>
           <p class="form-element">
             <label class="required">{{ $t('forms.label.email') }}</label>
-            <input v-model="form.email" type="email" :placeholder="$t('forms.placeholder.email')" required />
+            <input v-model="form.email" :placeholder="$t('forms.placeholder.email')" type="email" required />
           </p>
           <p class="form-element">
             <label class="required">{{ $t('forms.label.phone_number') }}</label>
@@ -82,7 +82,7 @@
           </p>
           <p class="form-element">
             <label>{{ $t('forms.label.pronouns') }}</label>
-            <input v-model="form.pronouns" type="text" :placeholder="$t('forms.placeholder.pronouns')" />
+            <input v-model="form.pronouns" :placeholder="$t('forms.placeholder.pronouns')" type="text" />
           </p>
           <p class="form-element">
             <label class="required">{{ $t('forms.label.membership_fee') }}</label>
@@ -97,7 +97,7 @@
           </p>
           <p class="form-element">
             <label class="required">{{ $t('forms.label.iban') }}</label>
-            <input v-model="form.iban" type="text" :placeholder="$t('forms.placeholder.iban')" required />
+            <input v-model="form.iban" :placeholder="$t('forms.placeholder.iban')" type="text" required />
           </p>
           <p class="form-element">
             <label>{{ $t('forms.label.remarks') }}</label>
@@ -105,7 +105,7 @@
           </p>
           <div id="recaptcha" />
           <p class="mt-8 md:my-8 text-right">
-            <button type="submit" class="button-pink" :disabled="formStatus === 'loading'">
+            <button :disabled="formStatus === 'loading'" type="submit" class="button-pink">
               {{ formStatus === 'loading' ? $t('forms.buttons.loading') : $t('forms.buttons.sign_up') }}
             </button>
           </p>


### PR DESCRIPTION
Applied the `--fix` flag of ESLint (and the Vue component). **Disabled two linting rules for props** that would make the code a lot longer to fix and don't add much since basically all of the props are strings. This fixes all of the linting warnings as mentioned in issue #26 

Secondarily, fixed a warning about deprecated use of `router.scrollBehavior` in issue #28 