### PR TITLE
Link Announcements chat to Outsite contact page

### DIFF
--- a/pages/chatgroups.vue
+++ b/pages/chatgroups.vue
@@ -55,7 +55,6 @@ export default {
   data() {
     return {
       chatLinks: {
-        Outsite: 'https://outsite.nl/#contact',
         Announcements: 'https://outsite.nl/#contact',
         Discord: 'https://dwhdelft.nl/discord',
         EatingOUT: 'https://chat.whatsapp.com/FlIbRLHUlzv1dvdv0WOisV',

--- a/pages/chatgroups.vue
+++ b/pages/chatgroups.vue
@@ -56,7 +56,7 @@ export default {
     return {
       chatLinks: {
         Outsite: 'https://outsite.nl/#contact',
-        Announcements: 'https://chat.whatsapp.com/5yMBCohMukj1oCVR4lPHer',
+        Announcements: 'https://outsite.nl/#contact',
         Discord: 'https://dwhdelft.nl/discord',
         EatingOUT: 'https://chat.whatsapp.com/FlIbRLHUlzv1dvdv0WOisV',
         'Saturday bar': 'https://chat.whatsapp.com/DjwXYRiaO1ZEhZS1vUOYjp',


### PR DESCRIPTION
The announcement chat was linked to directly while elsewhere on the website you have to sign up to join.
Now user's instead are linked to the Outsite page where they can sign up for the Announcements chat.

In future it might be nice to add a checkbox for when users sign up so that someone can say they also want to join the informal chat as well.