### PR TITLE
Revert "fix meta translation"

### DIFF
--- a/assets/lang/en.js
+++ b/assets/lang/en.js
@@ -1,13 +1,4 @@
 export default {
-  meta: {
-    home: {
-      title: 'DWH - LGBT+ association Delft',
-      description: `
-        DWH is the independent LGBT+ association of Delft and surroundings. We're two things, a meeting place for
-        LGBT+ people and their friends and a group that actively pushes for greater LGBT+ rights and acceptance.
-      `,
-    },
-  },
   forms: {
     label: {
       name: 'How should we call you?',

--- a/assets/lang/nl.js
+++ b/assets/lang/nl.js
@@ -1,13 +1,4 @@
 export default {
-  meta: {
-    home: {
-      title: 'DWH - LHBT+ vereniging Delft',
-      description: `
-        DWH is dé onafhankelijke LHBT+ vereniging van Delft en omgeving. We zijn twee dingen; een ontmoetingsplek 
-        voor LHBT+ mensen en hun vrienden en een groep die actief strijdt voor meer LHBT+ rechten en acceptatie.
-      `,
-    },
-  },
   forms: {
     label: {
       name: 'Hoe mogen we je noemen?',

--- a/sites/dwhdelft.nl/nuxt.config.js
+++ b/sites/dwhdelft.nl/nuxt.config.js
@@ -13,27 +13,27 @@ export default {
   },
 
   // Global page headers (https://go.nuxtjs.dev/config-head)
-  head() {
-    return {
-      title: this.$i18n.t('meta.home.title'),
-      meta: [
-        { charset: 'utf-8' },
-        { name: 'viewport', content: 'width=device-width, initial-scale=1' },
-        {
-          hid: 'description',
-          name: 'description',
-          content: this.$i18n.t('meta.home.description'),
-        },
-        { hid: 'apple-mobile-web-app-title', property: 'apple-mobile-web-app-title', content: 'DWH Delft' },
-      ],
-      link: [
-        { rel: 'icon', type: 'image/png', sizes: '32x32', href: '/favicon-32x32.png' },
-        { rel: 'icon', type: 'image/png', sizes: '16x16', href: '/favicon-16x16.png' },
-        { rel: 'manifest', href: '/site.webmanifest' },
-        { rel: 'mask-icon', href: '/safari-pinned-tab.svg', color: '#e31c79' },
-        { rel: 'apple-touch-icon', sizes: '180x180', href: '/apple-touch-icon.png' },
-      ],
-    }
+  head: {
+    title: 'DWH - LHBT+ vereniging Delft',
+    meta: [
+      { charset: 'utf-8' },
+      { name: 'viewport', content: 'width=device-width, initial-scale=1' },
+      {
+        hid: 'description',
+        name: 'description',
+        content:
+          'DWH is dé onafhankelijke LHBT+ vereniging van Delft en omgeving. We zijn twee dingen; een ontmoetingsplek ' +
+          'voor LHBT+ mensen en hun vrienden en een groep die actief strijdt voor meer LHBT+ rechten en acceptatie.',
+      },
+      { hid: 'apple-mobile-web-app-title', property: 'apple-mobile-web-app-title', content: 'DWH Delft' },
+    ],
+    link: [
+      { rel: 'icon', type: 'image/png', sizes: '32x32', href: '/favicon-32x32.png' },
+      { rel: 'icon', type: 'image/png', sizes: '16x16', href: '/favicon-16x16.png' },
+      { rel: 'manifest', href: '/site.webmanifest' },
+      { rel: 'mask-icon', href: '/safari-pinned-tab.svg', color: '#e31c79' },
+      { rel: 'apple-touch-icon', sizes: '180x180', href: '/apple-touch-icon.png' },
+    ],
   },
 
   // Aliases (https://nuxtjs.org/docs/2.x/configuration-glossary/configuration-alias)


### PR DESCRIPTION
Reverts dwh-outsite/dwhdelft.nl#340

```
 FATAL  Cannot read properties of undefined (reading 't')                                                                                                                     21:55:59

  at Object.head (nuxt.config.js:18:25)
  at SPARenderer.render (/Users/casperboone/Code/dwh/dwhdelft.nl/node_modules/@nuxt/vue-renderer/dist/vue-renderer.js:107:24)
  at VueRenderer.renderSPA (/Users/casperboone/Code/dwh/dwhdelft.nl/node_modules/@nuxt/vue-renderer/dist/vue-renderer.js:908:30)
  at VueRenderer.renderRoute (/Users/casperboone/Code/dwh/dwhdelft.nl/node_modules/@nuxt/vue-renderer/dist/vue-renderer.js:982:14)
  at async Generator.afterGenerate (/Users/casperboone/Code/dwh/dwhdelft.nl/node_modules/@nuxt/generator/dist/generator.js:253:20)
  at async Generator.generate (/Users/casperboone/Code/dwh/dwhdelft.nl/node_modules/@nuxt/generator/dist/generator.js:79:5)
  at async generate$1 (/Users/casperboone/Code/dwh/dwhdelft.nl/node_modules/@nuxt/cli/dist/cli-generate.js:46:22)
  at async Object.run (/Users/casperboone/Code/dwh/dwhdelft.nl/node_modules/@nuxt/cli/dist/cli-generate.js:284:7)
  at async NuxtCommand.run (/Users/casperboone/Code/dwh/dwhdelft.nl/node_modules/@nuxt/cli/dist/cli-index.js:413:7)
```