### PR TITLE
Fix #513 Low contrast for links in faculty overview

### DIFF
--- a/sites/dwhdelft.nl/pages/resources.vue
+++ b/sites/dwhdelft.nl/pages/resources.vue
@@ -283,4 +283,12 @@ export default {
   @apply bg-cover;
   background-image: url(../../../assets/images/events/purplefriday/purple_friday_2021_bg.svg);
 }
+
+.content >>> p a {
+  @apply text-white font-bold;
+}
+
+.content >>> p a:hover {
+  @apply text-brand-300;
+}
 </style>


### PR DESCRIPTION
The faculty overview copies some standard css things for content blocks, among which the text color of links. This adds some styling to the resources page to turn the links white and bold.