### PR TITLE
Mailchimp niewsbrief redirect, verder moet dit nog een locatie krijge…

### DIFF
--- a/content/redirects/nieuwsbrief.json
+++ b/content/redirects/nieuwsbrief.json
@@ -1,0 +1,4 @@
+{
+  "from": "/nieuwsbrief",
+  "to": "http://eepurl.com/dAWqcb"
+}


### PR DESCRIPTION
…n op de website zelf maar een dwhdelft.nl/nieuwsbrief is al fijner om aan mensen te geven dan de short url van mailchimp