### PR TITLE
Add a redirect to the Committee Interest form (/interested)

### DIFF
--- a/content/redirects/interested.json
+++ b/content/redirects/interested.json
@@ -1,0 +1,4 @@
+{
+  "from": "/interested",
+  "to": "https://docs.google.com/forms/d/e/1FAIpQLScVFX8Vi2_eL8FU0VRw_DVKxhSV72uCjm7ZiAZHquf-vMPF6Q/viewform"
+}


### PR DESCRIPTION
I would like to make the committee interest form more accessible by printing a URL on the poster in addition to the QR code 