### PR TITLE
Add a redirect from `/interested` to the Committee Interest Form

### DIFF
--- a/shared/public/_redirects
+++ b/shared/public/_redirects
@@ -26,6 +26,7 @@
 /glasses https://drive.google.com/file/d/1RTBdrgVcft6Syy7W29gE-jwaiD68alI7/view?usp=sharing
 /gsadag https://docs.google.com/forms/d/e/1FAIpQLSc227a6ABEQ9p63GmYU1Ubo9VcNeFMv0bIewNrpR20la_HR8Q/viewform?usp=sf_link
 /inholland https://teams.microsoft.com/l/team/19%3apCGn5KJuCAbHEaqGRr0CtO2YZS7aqALBlQOdMs13Hwc1%40thread.tacv2/conversations?groupId=3baec2f7-f25b-44cf-b749-ccdbb8fc3ed6&tenantId=ad78d191-1044-4303-8212-b6f4dd7874bc
+/interested https://docs.google.com/forms/d/e/1FAIpQLScVFX8Vi2_eL8FU0VRw_DVKxhSV72uCjm7ZiAZHquf-vMPF6Q/viewform
 /jongenout-activiteit https://forms.gle/9MoseRHHscFuMw3j7
 /kmgform https://forms.gle/31AvY7EcJcUu921Z6
 kmgsignups https://docs.google.com/spreadsheets/d/1oeSrY5PfxwUQOxUuan-TT_0m7YDxADIHl4yERnWP7LE/edit?usp=sharing


### PR DESCRIPTION
Implementing https://github.com/dwh-outsite/dwhdelft.nl/pull/574#issuecomment-2186597380

Original description:
> I would like to make the committee interest form more accessible by printing a URL on the poster in addition to the QR code

