### PR TITLE
fixed responsiveness for mixup logo and buttons

### DIFF
--- a/dwhdelft.nl/pages/mixup.vue
+++ b/dwhdelft.nl/pages/mixup.vue
@@ -117,7 +117,7 @@ const instagramChannelsMixup = [
           <div class="space-y-4">
             <ElementsParagraphedText :paragraphs="t('intro')" class="md:text-xl md:leading-relaxed space-y-4" />
             <div>
-              <div class="flex flex-1 space-x-8 space-y-16 md:space-y-8 lg:space-y-6">
+              <div class="flex flex-1 flex-wrap justify-center items-center gap-4">
                 <div>
                   <p
                     v-if="barOpeningHours.announcement"
@@ -134,15 +134,15 @@ const instagramChannelsMixup = [
                   <MIXUPLogo class="h-20" />
                 </div>
               </div>
-              <div class="flex flex-1 space-x-4">
-                <div>
+              <div class="flex flex-1 flex-wrap justify-center items-center space-x-4 mt-2">
+                <div class="m-2">
                   <a href="https://my.dwhdelft.nl/signup">
                     <ElementsSecondaryButton class="!text-brand-450" arrow>
                       {{ t('membership_button') }}
                     </ElementsSecondaryButton>
                   </a>
                 </div>
-                <div>
+                <div class="m-2">
                   <nuxt-link :to="localePath('barbuddy')">
                     <ElementsPrimaryButton class="!text-brand-50" arrow>
                       {{ t('barbuddy_button') }}


### PR DESCRIPTION
The mixup logo and buttons failed to go to the newline in small mobile screens.
![dwhdelft nl_mixup (2)](https://github.com/user-attachments/assets/730b30c4-42d7-4261-aa63-008485eb6694)
![dwhdelft nl_mixup (1)](https://github.com/user-attachments/assets/0aaa7440-e4aa-447a-a1e7-eec850255dc6)
![dwhdelft nl_mixup](https://github.com/user-attachments/assets/dbc6c9b3-3ee1-49aa-abba-6f0dec72ba96)

I made changes to the flex behaviour and the margins to make it look more natural for all screen sizes. This is how it currently looks:
![localhost_3000_mixup (1)](https://github.com/user-attachments/assets/bf468473-d85e-478b-bde2-83f220a64f75)
![localhost_3000_mixup (2)](https://github.com/user-attachments/assets/e177bb75-a94d-42cb-8977-1539bbcefb31)
![localhost_3000_mixup (3)](https://github.com/user-attachments/assets/9b05b163-25fd-4461-becc-8dbeae500cfa)
