### PR TITLE
feat(redirect): set decla link to new bookkeping form

### DIFF
--- a/shared/public/_redirects
+++ b/shared/public/_redirects
@@ -18,8 +18,8 @@
 /committees /activities
 /confidential-counsellor https://dwhdelft.nl/lets-talk
 /crazy55 https://forms.gle/5pP9a5CAuh7bGQpr8
-/declaratie https://forms.gle/DDEFaz1uUu1znvyF6
-/declareer https://forms.gle/DDEFaz1uUu1znvyF6
+/declaratie https://bookkeeping.dwhdelft.nl/declaratie/
+/declareer https://bookkeeping.dwhdelft.nl/declaratie/
 /dinnershow https://www.ticketkantoor.nl/shop/dragdinnershow
 /discord https://discord.gg/RDwtnRK
 /donate https://www.ing.nl/payreq/m/?trxid=yXCo8cATXEyrHLH2wObNfdXU10UR5yXp


### PR DESCRIPTION
Redirects /declaratie and /declareer to the [bookkeeping decla form](https://bookkeeping.dwhdelft.nl/declaratie/) instead of the google form